### PR TITLE
Add \n before fence chars at the end of a code block. Otherwise the m…

### DIFF
--- a/packages/turndown/src/plugins/juejinCodeBlock.ts
+++ b/packages/turndown/src/plugins/juejinCodeBlock.ts
@@ -26,7 +26,7 @@ export default function (turndownService: TurndownService) {
         return content;
       }
       node.querySelector('.copy-code-btn')?.remove();
-      return `\`\`\`${(node.firstChild as HTMLElement)?.getAttribute('lang')}\n${node.firstChild?.textContent}\`\`\`\n\n`;
+      return `\`\`\`${(node.firstChild as HTMLElement)?.getAttribute('lang')}\n${node.firstChild?.textContent}\n\`\`\`\n\n`;
     },
   });
 }


### PR DESCRIPTION
# Problem
- Code block end not detected correctly.
- Site: https://developer.aliyun.com/article/780727?groupCode=hologres
- Image:
![image](https://user-images.githubusercontent.com/915546/103400093-d6677900-4b7e-11eb-945c-3142b158696f.png)

# Solution

For add \n at the code of the code block.